### PR TITLE
Move the list of notifications into QML so we get fancy animations

### DIFF
--- a/qmldesktop.pro
+++ b/qmldesktop.pro
@@ -11,7 +11,8 @@ INCLUDEPATH = src
 # Input
 SOURCES += \
     src/qmldesktop_plugin.cpp \
-    src/mprisconnection.cpp
+    src/mprisconnection.cpp \
+    src/notificationserver.cpp
 
 HEADERS += \
     src/mprisconnection.h \

--- a/src/notificationadaptor.h
+++ b/src/notificationadaptor.h
@@ -7,26 +7,37 @@
 #include <QSignalMapper>
 #include <QList>
 #include "notification.h"
+#include <QDebug>
+#include <QQmlListProperty>
+#include <notificationserver.h>
 
 class NotificationAdaptor : public QDBusAbstractAdaptor
 {
+
     Q_OBJECT
     Q_CLASSINFO("D-Bus Interface", "org.freedesktop.Notifications")
 public:
-    NotificationAdaptor(QObject *parent) : QDBusAbstractAdaptor(parent), availableId(1) {}
-    QList<Notification*> notifications;
+
+    enum CloseReason {
+        Expired = 1,
+        Dismissed = 2,
+        Requested = 3,
+        Unknown = 4
+    };
+
+    NotificationAdaptor(QObject *parent, NotificationServer *server) : QDBusAbstractAdaptor(parent), availableId(1) {
+        this->server = server;
+        qDebug() << "Adapter ready!";
+    }
+
 public slots:
     QStringList GetCapabilities() {
         return QStringList() << "body";
     }
     void CloseNotification(uint id) {
-        for (int i = 0; i < notifications.length(); i++){
-            if (notifications[i]->m_id == id) {
-                notifications.removeAt(i);
-            }
-        }
-        emit notificationsChanged();
-        emit NotificationClosed(id, 3);
+        server->notificationRemoved(id);
+
+        emit NotificationClosed(id, Requested);
     }
     void GetServerInformation(QString &name, QString &vendor, QString &version, QString &spec_version){
         name = "Quantum OS Notification Server";
@@ -35,55 +46,60 @@ public slots:
         //not sure, I think so
         spec_version = "1.2";
     }
+
     uint Notify(QString app_name, uint replaces_id, QString app_icon, QString summary, QString body, QStringList actions, QVariantMap hints, int expire_timeout) {
+
+        qDebug() << "Notification" << app_name << summary << body << replaces_id;
+
         Notification *notification = new Notification(app_name, (replaces_id == 0 ? availableId++ : replaces_id), app_icon, summary, body, actions, hints, expire_timeout);
-        if (replaces_id != 0) {
-            for (int i = 0; i < notifications.length(); i++){
-                if (notifications[i]->m_id == replaces_id) {
-                    notifications.replace(i, notification);
-                    if (expire_timeout != -1 && expire_timeout != 0) {
-                        QSignalMapper *mapper = new QSignalMapper(this);
-                        QObject::connect(mapper, SIGNAL(mapped(QString)), this, SLOT(forTimer(QString)));
-                        QTimer *timer = new QTimer(this);
-                        QObject::connect(timer, SIGNAL(timeout()), mapper, SLOT(map()));
-                        mapper->setMapping(timer, QVariant(replaces_id).toString());
-                        timer->setSingleShot(true);
-                        timer->start(expire_timeout);
-                    }
-                    emit notificationsChanged();
-                }
-            }
-        } else {
-            notifications << notification;
-            if (expire_timeout != -1 && expire_timeout != 0){
-                QSignalMapper *mapper = new QSignalMapper(this);
-                QObject::connect(mapper, SIGNAL(mapped(QString)), this, SLOT(forTimer(QString)));
-                QTimer *timer = new QTimer(this);
-                QObject::connect(timer, SIGNAL(timeout()), mapper, SLOT(map()));
-                mapper->setMapping(timer, QVariant(availableId-1).toString());
-                timer->setSingleShot(true);
-                timer->start(expire_timeout);
-            }
-            emit notificationsChanged();
+
+        if (expire_timeout == 0) {
+            expire_timeout = 2500;
         }
-        return (replaces_id == 0 ? availableId-1 : replaces_id);
+
+        if (expire_timeout != -1) {
+            qDebug() << "Expiring in" << expire_timeout << "milliseconds";
+
+            QSignalMapper *mapper = new QSignalMapper(this);
+            QObject::connect(mapper, SIGNAL(mapped(QString)), this, SLOT(forTimer(QString)));
+            QTimer *timer = new QTimer(this);
+            QObject::connect(timer, SIGNAL(timeout()), mapper, SLOT(map()));
+            mapper->setMapping(timer, QVariant(notification->m_id).toString());
+            timer->setSingleShot(true);
+            timer->start(expire_timeout);
+        } else {
+            qDebug() << "Notification doesn't time out!";
+        }
+
+        if (replaces_id != 0) {
+            server->notificationUpdated(replaces_id, QVariant(QMetaType::QObjectStar, &notification));
+        } else {
+            server->notificationAdded(notification->m_id, QVariant(QMetaType::QObjectStar, &notification));
+        }
+
+        return notification->m_id;
     }
+
+    void closeNotification(int id) {
+        server->notificationRemoved(id);
+        emit NotificationClosed(id, Dismissed);
+    }
+
 signals:
     void NotificationClosed(uint id, uint reason);
     void ActionInvoked(uint id, QString action_key);
-    void notificationsChanged();
-private:
-    uint availableId;
+
 private slots:
+
     void forTimer(QString id) {
-        for (int i = 0; i < notifications.length(); i++){
-            if (notifications[i]->m_id == QVariant(id).toUInt()) {
-                notifications.removeAt(i);
-                emit NotificationClosed(QVariant(id).toUInt(), 1);
-                emit notificationsChanged();
-            }
-        }
+        server->notificationRemoved(id.toInt());
+        emit NotificationClosed(QVariant(id).toUInt(), Expired);
     }
+
+private:
+
+    uint availableId;
+    NotificationServer *server;
 };
 
 #endif // NOTIFICATIONADAPTOR_H

--- a/src/notificationserver.cpp
+++ b/src/notificationserver.cpp
@@ -1,0 +1,12 @@
+#include "notificationserver.h"
+#include "notificationadaptor.h"
+
+NotificationServer::NotificationServer(QQuickItem *parent) : QQuickItem(parent) {
+    adaptor = new NotificationAdaptor(parent, this);
+    qDebug() << "Registering object: " << QDBusConnection::sessionBus().registerObject("/org/freedesktop/Notifications", parent);
+    qDebug() << "Registering service: " << QDBusConnection::sessionBus().registerService("org.freedesktop.Notifications");
+}
+
+void NotificationServer::closeNotification(int id) {
+    adaptor->closeNotification(id);
+}

--- a/src/notificationserver.h
+++ b/src/notificationserver.h
@@ -7,33 +7,27 @@
 #include <QDBusConnection>
 #include <QObject>
 #include "notification.h"
-#include "notificationadaptor.h"
+
+class NotificationAdaptor;
 
 class NotificationServer : public QQuickItem
 {
     Q_OBJECT
     Q_DISABLE_COPY(NotificationServer)
-    Q_PROPERTY(QQmlListProperty<Notification> notifications READ notifications NOTIFY notificationsChanged)
 
 public:
-    explicit NotificationServer(QQuickItem *parent = new QQuickItem()) : QQuickItem(parent) {
-        adaptor = new NotificationAdaptor(parent);
-        QDBusConnection::sessionBus().registerObject("/org/freedesktop/Notifications", parent);
-        QDBusConnection::sessionBus().registerService("org.freedesktop.Notifications");
-        QObject::connect(adaptor, SIGNAL(notificationsChanged()), this, SLOT(emitNotificationsChanged()));
-    }
-    QQmlListProperty<Notification> notifications() {
-        return QQmlListProperty<Notification>(this, adaptor->notifications);
-    }
+    explicit NotificationServer(QQuickItem *parent = new QQuickItem());
+
+public slots:
+    void closeNotification(int id);
+
 private:
     NotificationAdaptor* adaptor;
-private slots:
-    void emitNotificationsChanged(){
-        emit notificationsChanged();
-    }
 
 signals:
-    void notificationsChanged();
+    void notificationUpdated(int id, QVariant notification);
+    void notificationAdded(int id, QVariant notification);
+    void notificationRemoved(int id);
 };
 
 #endif // NOTIFICATIONSERVER_H

--- a/src/qmldesktop_plugin.cpp
+++ b/src/qmldesktop_plugin.cpp
@@ -12,7 +12,7 @@ void DesktopPlugin::registerTypes(const char *uri)
     qmlRegisterType<MprisConnection>(uri, 0, 1, "MprisConnection");
     qmlRegisterType<NotificationServer>(uri, 0, 1, "NotificationServer");
     qmlRegisterUncreatableType<Mpris2Player>(uri, 0, 1, "Mpris2Player", "Player class");
-    qmlRegisterUncreatableType<Notification>(uri, 0, 1, "Notifiation", "For NotificationServer");
+    qmlRegisterUncreatableType<Notification>(uri, 0, 1, "Notification", "For NotificationServer");
 }
 
 


### PR DESCRIPTION
Each time a notification was created, it reloaded the entire list, which prevented fancy animations. I set up signals that the QML can connect to, so it can then be handled via a ListModel in QML, allowing for some fancy animations which I will demo soon.